### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,22 +31,22 @@
   },
   "homepage": "http://gr2m.github.io/humble-localstorage/",
   "devDependencies": {
-    "browserify": "^11.0.1",
-    "chai": "^3.2.0",
-    "derequire": "^2.0.2",
+    "browserify": "11.2.0",
+    "chai": "3.3.0",
+    "derequire": "2.0.2",
     "doxx": "^1.5.0",
-    "expect.js": "^0.3.1",
-    "gh-pages-deploy": "^0.3.0",
-    "jshint": "^2.8.0",
-    "mocha": "^2.3.0",
-    "sinon": "^1.16.1",
-    "testmate": "^1.0.1",
-    "uglify-js": "^2.4.24",
-    "semantic-release": "^4.3.4"
+    "expect.js": "0.3.1",
+    "gh-pages-deploy": "0.3.0",
+    "jshint": "2.8.0",
+    "mocha": "2.3.3",
+    "sinon": "1.17.0",
+    "testmate": "1.0.1",
+    "uglify-js": "2.4.24",
+    "semantic-release": "4.3.5"
   },
   "dependencies": {
-    "has-localstorage": "^1.0.1",
-    "localstorage-memory": "^1.0.1"
+    "has-localstorage": "1.0.1",
+    "localstorage-memory": "1.0.1"
   },
   "gh-pages-deploy": {
     "staticpath": "docs",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:
